### PR TITLE
fix: add v char before version

### DIFF
--- a/src/services/positionService.ts
+++ b/src/services/positionService.ts
@@ -998,8 +998,8 @@ export default class PositionService {
       case TRANSACTION_TYPES.NEW_POSITION: {
         const newPositionTypeData = transaction.typeData as NewPositionTypeData;
         const newId = newPositionTypeData.id;
-        if (!this.currentPositions[`${newId}-${newPositionTypeData.version}`]) {
-          this.currentPositions[`${newId}-${newPositionTypeData.version}`] = {
+        if (!this.currentPositions[`${newId}-v${newPositionTypeData.version}`]) {
+          this.currentPositions[`${newId}-v${newPositionTypeData.version}`] = {
             ...this.currentPositions[`pending-transaction-${transaction.hash}-v${newPositionTypeData.version}`],
             pendingTransaction: '',
             id: `${newId}-v${newPositionTypeData.version}`,


### PR DESCRIPTION
`TRANSACTION_TYPES.NEW_POSITION` was missing a `"v"` char in the id, so then on `src/services/positionService.ts:160` we failed to get the position and update it with data from the positions api call, hence creating a new position that appeared as duplicate until we refreshed the client.