### PR TITLE
fix check by using lowecase

### DIFF
--- a/src/common/modify-settings-modal/index.tsx
+++ b/src/common/modify-settings-modal/index.tsx
@@ -120,7 +120,7 @@ const ModifySettingsModal = ({ position, open, onCancel }: ModifySettingsModalPr
 
   const needsToApprove =
     fromToUse.address !== PROTOCOL_TOKEN_ADDRESS &&
-    position.user === walletService.getAccount() &&
+    position.user === walletService.getAccount().toLowerCase() &&
     allowance &&
     allowance.token.address !== PROTOCOL_TOKEN_ADDRESS &&
     isIncreasingPosition &&


### PR DESCRIPTION
 The check `position.user === walletService.getAccount()` failed because `walletService.getAccount()` had uppercases while `position.user` didn't, so we were never shown the "Approve" button in the position edition modal.