### PR TITLE
refactor: remove dist from sdk import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint-staged": ">=10",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",
-    "process": "^0.11.10",
+    "process": "0.11.10",
     "react-hot-loader": "^4.13.0",
     "redux-devtools": "^3.7.0",
     "style-loader": "^2.0.0",

--- a/src/aggregator/swap-container/components/quote-simulation/index.tsx
+++ b/src/aggregator/swap-container/components/quote-simulation/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { QuoteTx } from '@mean-finance/sdk/dist/services/quotes/types';
+import { QuoteTx } from '@mean-finance/sdk/services/quotes/types';
 import useSimulateTransaction from 'hooks/useSimulateTransaction';
 import CenteredLoadingIndicator from 'common/centered-loading-indicator';
 import Typography from '@mui/material/Typography';

--- a/src/aggregator/swap-container/components/quotes/index.tsx
+++ b/src/aggregator/swap-container/components/quotes/index.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import { withStyles } from '@mui/styles';
-import { SourceMetadata } from '@mean-finance/sdk/dist/services/quotes/types';
+import { SourceMetadata } from '@mean-finance/sdk/services/quotes/types';
 import compact from 'lodash/compact';
 import Chip from '@mui/material/Chip';
 import styled from 'styled-components';

--- a/src/config/constants/addresses.ts
+++ b/src/config/constants/addresses.ts
@@ -3,7 +3,7 @@
 import { Chains, getAllChains } from '@mean-finance/sdk';
 import { NetworkStruct } from 'types';
 import findKey from 'lodash/findKey';
-import { Chain } from '@mean-finance/sdk/dist/types';
+import { Chain } from '@mean-finance/sdk/types';
 import {
   POSITION_VERSION_2,
   POSITION_VERSION_3,

--- a/src/hooks/useSimulateTransaction.ts
+++ b/src/hooks/useSimulateTransaction.ts
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual';
 import { BlowfishResponse } from 'types';
 import debounce from 'lodash/debounce';
 import usePrevious from 'hooks/usePrevious';
-import { QuoteTx } from '@mean-finance/sdk/dist/services/quotes/types';
+import { QuoteTx } from '@mean-finance/sdk/services/quotes/types';
 import useSimulationService from './useSimulationService';
 
 export const ALL_SWAP_OPTIONS_FAILED = 'all swap options failed';

--- a/src/services/aggregatorService.ts
+++ b/src/services/aggregatorService.ts
@@ -12,7 +12,7 @@ import { Interface } from '@ethersproject/abi';
 import ERC20ABI from 'abis/erc20.json';
 import WRAPPEDABI from 'abis/weth.json';
 import { getProtocolToken } from 'mocks/tokens';
-import { QuoteResponse } from '@mean-finance/sdk/dist/services/quotes/types';
+import { QuoteResponse } from '@mean-finance/sdk/services/quotes/types';
 import { GasKeys, SwapSortOptions } from 'config/constants/aggregator';
 import GraphqlService from './graphql';
 import ContractService from './contractService';

--- a/src/services/simulationService.ts
+++ b/src/services/simulationService.ts
@@ -1,4 +1,4 @@
-import { QuoteTx } from '@mean-finance/sdk/dist/services/quotes/types';
+import { QuoteTx } from '@mean-finance/sdk/services/quotes/types';
 import { BLOWFISH_ENABLED_CHAINS } from 'config';
 import { BlowfishResponse } from 'types';
 

--- a/src/types/aggregator.ts
+++ b/src/types/aggregator.ts
@@ -1,4 +1,4 @@
-import { QuoteTx } from '@mean-finance/sdk/dist/services/quotes/types';
+import { QuoteTx } from '@mean-finance/sdk/services/quotes/types';
 import { BigNumber } from 'ethers';
 import { Token } from './tokens';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import type Web3Service from 'services/web3Service';
 import React from 'react';
-import { QuoteTx } from '@mean-finance/sdk/dist/services/quotes/types';
+import { QuoteTx } from '@mean-finance/sdk/services/quotes/types';
 import { BigNumber } from 'ethers';
 import { Token } from './tokens';
 import { BlowfishResponse } from './responses';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10359,7 +10359,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
+process@0.11.10, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==


### PR DESCRIPTION
this will make it easier to link the SDK. blz do test it locally without all the links. remember to `yarn install --force`
