### PR TITLE
chore: update sdk to 0.0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@mean-finance/dca-v2-core": "^3.1.5",
     "@mean-finance/dca-v2-periphery": "^3.3.0",
     "@mean-finance/oracles": "^2.1.4",
-    "@mean-finance/sdk": "0.0.32",
+    "@mean-finance/sdk": "0.0.36",
     "@mean-finance/transformers": "^1.0.0",
     "@metamask/detect-provider": "^1.2.0",
     "@mui-treasury/components": "^1.10.1",

--- a/src/services/sdkService.ts
+++ b/src/services/sdkService.ts
@@ -11,7 +11,7 @@ import ProviderService from './providerService';
 import WalletService from './walletService';
 
 export default class SdkService {
-  sdk: ReturnType<typeof buildSDK>;
+  sdk: ReturnType<typeof buildSDK<{}>>;
 
   walletService: WalletService;
 

--- a/src/services/sdkService.ts
+++ b/src/services/sdkService.ts
@@ -47,7 +47,7 @@ export default class SdkService {
                     `https://api.mean.finance/v1/swap/networks/${chainId}/quotes`,
                   sources: SOURCES_METADATA,
                 },
-                sourceIds: ['uniswap', 'odos', 'firebird', 'rango'],
+                sourceIds: ['uniswap', 'odos', 'firebird', 'rango', '0x'],
               },
             ],
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,10 +2553,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.32.tgz#ed41ca17a8567461e3fc8dab02a8c5eae53aef65"
-  integrity sha512-XZDJemR77DSpL+54GqMCVLgeozBLmiY2nX9lg9k/jpn3qkxKpnbXLOd9zHQ1jqVyFuzI/snoJm4F0dsLZl3SOQ==
+"@mean-finance/sdk@0.0.36":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.36.tgz#00c412476a4a2560bc153ece97d026a0e7933b34"
+  integrity sha512-PfLkBqbIbhIyzs2WhfNJ+jO/QKPY9HbT8nXdX0NIdvkOMeT4iua2GlP0GD5YwjsYh1Ym5yUu9mF6XC9yyJKWew==
   dependencies:
     cross-fetch "3.1.5"
     ethers "5.7.2"


### PR DESCRIPTION
We are now making two changes:
1. We are updating the SDK to the newest version, which has some bug fixes
2. We are now using 0x from the API, since we now have an API key, which allows for some more rate limiting