### PR TITLE
chore: enable wsteth on ethereum

### DIFF
--- a/src/config/constants/common.ts
+++ b/src/config/constants/common.ts
@@ -59,7 +59,6 @@ export const TRANSACTION_ACTION_TYPES: Record<TransactionActionType, Transaction
 };
 
 export const TOKEN_BLACKLIST = [
-  '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0', // ETH - WSTETH. Disabled until we test it.
   '0x5fe2b58c013d7601147dcdd68c143a77499f5531', // POLY - GRT
   '0x50b728d8d964fd00c2d0aad81718b71311fef68a', // POLY - SNX
   '0x65559aa14915a70190438ef90104769e5e890a00', // OE - ENS

--- a/src/config/constants/yield.ts
+++ b/src/config/constants/yield.ts
@@ -401,12 +401,12 @@ export const ALLOWED_YIELDS: Record<number, Pick<YieldOption, 'id' | 'poolId' | 
         name: 'Euler',
         token: emptyTokenWithAddress('EULER'),
       },
-      {
-        id: '1e31049a-403b-4029-a662-4342e70c20b8', // euler wstETH
-        tokenAddress: '0x7C6D161b367Ec0605260628c37B8dd778446256b', // euler wstETH
-        poolId: '1e31049a-403b-4029-a662-4342e70c20b8', // euler wstETH
-        name: 'Euler',
-        token: emptyTokenWithAddress('EULER'),
-      },
+      // {
+      //   id: '1e31049a-403b-4029-a662-4342e70c20b8', // euler wstETH
+      //   tokenAddress: '0x7C6D161b367Ec0605260628c37B8dd778446256b', // euler wstETH
+      //   poolId: '1e31049a-403b-4029-a662-4342e70c20b8', // euler wstETH
+      //   name: 'Euler',
+      //   token: emptyTokenWithAddress('EULER'),
+      // },
     ],
   };


### PR DESCRIPTION
This should only be merged once we've tested `wstETH` on Ethereum. For now, yield will not be supported.