### PR TITLE
chore: update sdk and use odos locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@mean-finance/dca-v2-core": "^3.1.5",
     "@mean-finance/dca-v2-periphery": "^3.3.0",
     "@mean-finance/oracles": "^2.1.4",
-    "@mean-finance/sdk": "0.0.79",
+    "@mean-finance/sdk": "0.0.87",
     "@mean-finance/transformers": "^1.0.0",
     "@metamask/detect-provider": "^1.2.0",
     "@mui/icons-material": "^5.6.2",

--- a/src/services/sdkService.ts
+++ b/src/services/sdkService.ts
@@ -54,7 +54,7 @@ export default class SdkService {
                     `${MEAN_API_URL}/v1/swap/networks/${chainId}/quotes/${sourceId}`,
                   sources: SOURCES_METADATA,
                 },
-                sourceIds: ['uniswap', 'odos', 'rango', '0x', 'firebird', 'changelly'],
+                sourceIds: ['uniswap', 'rango', '0x', 'firebird', 'changelly'],
               },
             ],
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2590,10 +2590,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@0.0.79":
-  version "0.0.79"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.79.tgz#5437713f59dd9171824f818e3dd65c9765e5f3e0"
-  integrity sha512-xR+X6l4IqkINYuJA02R7h0e8B3bewv2FYPSkKmAd4z7fUwJWga3e1ps329K77QEZV7eyjPKBnSJmz7ZxJ+6+CQ==
+"@mean-finance/sdk@0.0.87":
+  version "0.0.87"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.87.tgz#7df97c11a59e42db5aca17c45253ad0f696ec629"
+  integrity sha512-+w2d3ngFv7OZq6IGORRVfqTuFm4eXIB8FovBx+nvoGZa5H2eJfYuW5kbtTcmbzDm5HyL6RXISGzvsD6iYEgBrA==
   dependencies:
     alchemy-sdk "2.8.0"
     cross-fetch "3.1.5"


### PR DESCRIPTION
We are now:
- Updating the SDK to the latest version
- Using Odos locally, instead of going to the API