### PR TITLE
refactor: add mean price source

### DIFF
--- a/src/services/sdkService.ts
+++ b/src/services/sdkService.ts
@@ -60,6 +60,29 @@ export default class SdkService {
           },
         },
       },
+      price: {
+        source: {
+          type: 'cached',
+          config: {
+            expiration: {
+              useCachedValue: { ifUnder: '1m' },
+              useCachedValueIfCalculationFailed: { ifUnder: '5m' },
+            },
+            maxSize: 20,
+          },
+          underlyingSource: {
+            type: 'prioritized',
+            sources: [
+              { type: 'coingecko' },
+              { type: 'portals-fi' },
+              // We place Mean Finance before DefiLlama because DefiLlama can quote 4626 tokens, but they are updated once
+              // every hour. Mean's price source has the more up-to-date
+              { type: 'mean-finance' },
+              { type: 'defi-llama' },
+            ],
+          },
+        },
+      },
     });
   }
 


### PR DESCRIPTION
We are doing two things here:
1. We are adding Mean's price source as part of the sources that will be queried. This is because Defi Llama supports some 4626 tokens, but they are updated once every hour. So we need something that has more up-to-date prices
2. We are adding a small 1 min cache. Since users could perform various quotes for the same pair in a small time windows, we want to avoid rate limiting issues (specially with Coingecko), so we can cache them. The cache will hold up to 20 token prices, so it should have no impact on memory

