### PR TITLE
fix(aggregator): Loosing tokens after network switch

### DIFF
--- a/src/pages/aggregator/swap-container/components/swap-button/index.tsx
+++ b/src/pages/aggregator/swap-container/components/swap-button/index.tsx
@@ -14,7 +14,6 @@ import { PROTOCOL_TOKEN_ADDRESS, getWrappedProtocolToken } from '@common/mocks/t
 import { useAggregatorState } from '@state/aggregator/hooks';
 import useLoadedAsSafeApp from '@hooks/useLoadedAsSafeApp';
 import useWalletService from '@hooks/useWalletService';
-import useReplaceHistory from '@hooks/useReplaceHistory';
 import { useAppDispatch } from '@state/hooks';
 import find from 'lodash/find';
 import { NETWORKS } from '@constants';
@@ -63,7 +62,6 @@ const SwapButton = ({
   const isOnCorrectNetwork = actualCurrentNetwork.chainId === currentNetwork.chainId;
   const loadedAsSafeApp = useLoadedAsSafeApp();
   const walletService = useWalletService();
-  const replaceHistory = useReplaceHistory();
   const dispatch = useAppDispatch();
   const wrappedProtocolToken = getWrappedProtocolToken(currentNetwork.chainId);
 
@@ -85,7 +83,6 @@ const SwapButton = ({
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     walletService.changeNetwork(chainId, () => {
       const networkToSet = find(NETWORKS, { chainId });
-      replaceHistory(`/swap/${chainId}`);
       dispatch(setNetwork(networkToSet as NetworkStruct));
       if (networkToSet) {
         web3Service.setNetwork(networkToSet?.chainId);


### PR DESCRIPTION
## Context
Url was being reseted to `mean.finance/swap/chainId` before triggering a `window.location.reload()`, so selected tokens were lost.
The `chainId` param is already being updated in the URL by the network selector component.

## Demo
1. Enter to the Aggregator page and connect with a wallet that is not a `CHAIN_CHANGING_WALLETS_WITHOUT_REFRESH`
2. Change network using the Network Selector & select tokens to perform a swap
3. Click on the button 'Change network to XXXXX'

Site should refresh and selected tokens should persists.
