### PR TITLE
fix(aggregator): show MAX balance even when connected to other chains

### DIFF
--- a/src/pages/aggregator/swap-container/components/from-amount-input/index.tsx
+++ b/src/pages/aggregator/swap-container/components/from-amount-input/index.tsx
@@ -6,7 +6,6 @@ import FormHelperText from '@mui/material/FormHelperText';
 import useAccount from '@hooks/useAccount';
 import Typography from '@mui/material/Typography';
 import { FormattedMessage } from 'react-intl';
-import useSelectedNetwork from '@hooks/useSelectedNetwork';
 import useCurrentNetwork from '@hooks/useCurrentNetwork';
 import { emptyTokenWithAddress, formatCurrencyAmount } from '@common/utils/currency';
 import { BigNumber } from 'ethers';
@@ -73,7 +72,6 @@ const FromAmountInput = ({
 }: Props) => {
   const { from } = useAggregatorState();
   const account = useAccount();
-  const selectedNetwork = useSelectedNetwork();
   const currentNetwork = useCurrentNetwork();
   const dispatch = useAppDispatch();
   const trackEvent = useTrackEvent();
@@ -105,7 +103,7 @@ const FromAmountInput = ({
         <Typography variant="body1">
           <FormattedMessage description="youPay" defaultMessage="You pay" />
         </Typography>
-        {balance && from && currentNetwork.chainId === selectedNetwork.chainId && (
+        {balance && from && (
           <StyledFormHelperText onClick={onSetMaxBalance}>
             <FormattedMessage
               description="in wallet"


### PR DESCRIPTION
## Context
We were only showing MAX balance (in the from token) if the `chainId` selected by the user in the UI (the one stored by redux) is the same as the one active in the user's wallet
With this change, that validation is not being performed anymore, allowing the user to see it's MAX balance despite of the chain that is active in the wallet.

## Demo (Wallet in mainnet ; Dapp in Polygon)
Using `CHAIN_CHANGING_WALLETS_WITHOUT_REFRESH` (e.g. Rabby)
<img width="1710" alt="Screenshot 2023-09-18 at 17 07 18" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/2fe2fde5-6754-42dc-8210-e7a53c267669">

Using refreshing wallets (e.g. Metamask)
<img width="1710" alt="Screenshot 2023-09-18 at 17 06 47" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/badff1dd-d42f-4cde-9999-4e5fd851fca1">
