### PR TITLE
fix(current-positions): Wrong token name displayed on withdraw modal

### DIFF
--- a/src/pages/dca/positions/components/current-positions/index.tsx
+++ b/src/pages/dca/positions/components/current-positions/index.tsx
@@ -11,7 +11,6 @@ import useTransactionModal from '@hooks/useTransactionModal';
 import { useTransactionAdder } from '@state/transactions/hooks';
 import { ModeTypesIds, PERMISSIONS, SUPPORTED_NETWORKS } from '@constants';
 import { getProtocolToken, getWrappedProtocolToken, PROTOCOL_TOKEN_ADDRESS } from '@common/mocks/tokens';
-import useCurrentNetwork from '@hooks/useCurrentNetwork';
 import ModifySettingsModal from '@common/components/modify-settings-modal';
 import { useAppDispatch } from '@state/hooks';
 import { initializeModifyRateSettings } from '@state/modify-rate-settings/actions';
@@ -52,9 +51,6 @@ const CurrentPositions = ({ isLoading }: CurrentPositionsProps) => {
   const hasSignSupport = useSupportsSigning();
   const currentPositions = useCurrentPositions();
   const [setModalSuccess, setModalLoading, setModalError] = useTransactionModal();
-  const currentNetwork = useCurrentNetwork();
-  const protocolToken = getProtocolToken(currentNetwork.chainId);
-  const wrappedProtocolToken = getWrappedProtocolToken(currentNetwork.chainId);
   const addTransaction = useTransactionAdder();
   const positionService = usePositionService();
   const errorService = useErrorService();
@@ -95,6 +91,9 @@ const CurrentPositions = ({ isLoading }: CurrentPositionsProps) => {
   }
 
   const onWithdraw = async (position: Position, useProtocolToken = false) => {
+    const protocolToken = getProtocolToken(position.chainId);
+    const wrappedProtocolToken = getWrappedProtocolToken(position.chainId);
+
     try {
       const { positionId } = position;
       const hasPermission = await positionService.companionHasPermission(

--- a/src/pages/dca/positions/components/current-positions/index.tsx
+++ b/src/pages/dca/positions/components/current-positions/index.tsx
@@ -11,7 +11,7 @@ import useTransactionModal from '@hooks/useTransactionModal';
 import { useTransactionAdder } from '@state/transactions/hooks';
 import { ModeTypesIds, PERMISSIONS, SUPPORTED_NETWORKS } from '@constants';
 import { getProtocolToken, getWrappedProtocolToken, PROTOCOL_TOKEN_ADDRESS } from '@common/mocks/tokens';
-import useCurrentNetwork from '@hooks/useSelectedNetwork';
+import useCurrentNetwork from '@hooks/useCurrentNetwork';
 import ModifySettingsModal from '@common/components/modify-settings-modal';
 import { useAppDispatch } from '@state/hooks';
 import { initializeModifyRateSettings } from '@state/modify-rate-settings/actions';


### PR DESCRIPTION
## Context
When a user attempted to withdraw a token, the modal displayed ETH or WETH instead of the actual protocol token. 
This happened because of an incorrect currentNetwork value, which was always the mainnet. Now the currentNetwork value matches the one in use by the user.

## Demo
Expected behaviour
<img width="642" alt="Screenshot 2023-09-19 at 13 28 42" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/b5df1d56-b7b2-4603-aae3-05cf261a2399">
Current behaviour
<img width="713" alt="Screenshot 2023-09-19 at 13 29 08" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/ca967841-a436-49a7-83ed-3e1e71eb288e">
