### PR TITLE
feat(aggregator): start tracking failed quotes

### DIFF
--- a/src/common/utils/quotes.ts
+++ b/src/common/utils/quotes.ts
@@ -3,7 +3,7 @@ import { parseUnits } from '@ethersproject/units';
 import { v4 as uuidv4 } from 'uuid';
 import isUndefined from 'lodash/isUndefined';
 import { EstimatedQuoteResponseWithTx, QuoteResponse, QuoteTransaction } from '@mean-finance/sdk';
-import { SwapOption, SwapOptionWithTx } from '@types';
+import { QuoteErrorType, SwapOption, SwapOptionWithTx } from '@types';
 import { defineMessage } from 'react-intl';
 import { BigNumber } from 'ethers';
 import { formatCurrencyAmount, toToken } from './currency';
@@ -307,3 +307,19 @@ export const swapOptionToEstimatedQuoteResponseWithTx: (option: SwapOptionWithTx
     : undefined,
   estimatedTx: option.tx,
 });
+
+export const categorizeError = (errorMsg: string): QuoteErrorType => {
+  if (errorMsg.includes('timeouted')) {
+    return 'Timeout';
+  }
+  if (errorMsg.includes('Invalid or unregistered referral code')) {
+    return 'ReferralCode';
+  }
+  if (errorMsg.includes('Cannot convert undefined to a BigInt')) {
+    return 'BigIntConversion';
+  }
+  if (errorMsg.includes('Network request failed')) {
+    return 'NetworkRequest';
+  }
+  return 'Unknown';
+};

--- a/src/common/utils/quotes.ts
+++ b/src/common/utils/quotes.ts
@@ -3,7 +3,7 @@ import { parseUnits } from '@ethersproject/units';
 import { v4 as uuidv4 } from 'uuid';
 import isUndefined from 'lodash/isUndefined';
 import { EstimatedQuoteResponseWithTx, QuoteResponse, QuoteTransaction } from '@mean-finance/sdk';
-import { QuoteErrorType, SwapOption, SwapOptionWithTx } from '@types';
+import { QuoteErrors, SwapOption, SwapOptionWithTx } from '@types';
 import { defineMessage } from 'react-intl';
 import { BigNumber } from 'ethers';
 import { formatCurrencyAmount, toToken } from './currency';
@@ -308,18 +308,18 @@ export const swapOptionToEstimatedQuoteResponseWithTx: (option: SwapOptionWithTx
   estimatedTx: option.tx,
 });
 
-export const categorizeError = (errorMsg: string): QuoteErrorType => {
+export const categorizeError = (errorMsg: string): QuoteErrors => {
   if (errorMsg.includes('timeouted')) {
-    return 'Timeout';
+    return QuoteErrors.TIMEOUT;
   }
   if (errorMsg.includes('Invalid or unregistered referral code')) {
-    return 'ReferralCode';
+    return QuoteErrors.REFERRAL_CODE;
   }
   if (errorMsg.includes('Cannot convert undefined to a BigInt')) {
-    return 'BigIntConversion';
+    return QuoteErrors.BIGINT_CONVERSION;
   }
   if (errorMsg.includes('Network request failed')) {
-    return 'NetworkRequest';
+    return QuoteErrors.NETWORK_REQUEST;
   }
-  return 'Unknown';
+  return QuoteErrors.UNKNOWN;
 };

--- a/src/services/aggregatorService.ts
+++ b/src/services/aggregatorService.ts
@@ -11,8 +11,8 @@ import { Interface } from '@ethersproject/abi';
 import ERC20ABI from '@abis/erc20.json';
 import WRAPPEDABI from '@abis/weth.json';
 import { getProtocolToken } from '@common/mocks/tokens';
-import { quoteResponseToSwapOption } from '@common/utils/quotes';
-import { QuoteResponse } from '@mean-finance/sdk/dist/services/quotes/types';
+import { categorizeError, quoteResponseToSwapOption } from '@common/utils/quotes';
+import { FailedQuote, QuoteResponse } from '@mean-finance/sdk/dist/services/quotes/types';
 import { GasKeys, SORT_MOST_PROFIT, SwapSortOptions, TimeoutKey } from '@constants/aggregator';
 import GraphqlService from './graphql';
 import ContractService from './contractService';
@@ -21,6 +21,7 @@ import ProviderService from './providerService';
 import SdkService from './sdkService';
 import SafeService from './safeService';
 import SimulationService from './simulationService';
+import EventService from './eventService';
 
 export default class AggregatorService {
   signer: Signer;
@@ -39,6 +40,8 @@ export default class AggregatorService {
 
   simulationService: SimulationService;
 
+  eventService: EventService;
+
   constructor(
     walletService: WalletService,
     contractService: ContractService,
@@ -46,7 +49,8 @@ export default class AggregatorService {
     DCASubgraph: Record<PositionVersions, Record<number, GraphqlService>>,
     providerService: ProviderService,
     safeService: SafeService,
-    simulationService: SimulationService
+    simulationService: SimulationService,
+    eventService: EventService
   ) {
     this.contractService = contractService;
     this.walletService = walletService;
@@ -55,6 +59,7 @@ export default class AggregatorService {
     this.providerService = providerService;
     this.safeService = safeService;
     this.simulationService = simulationService;
+    this.eventService = eventService;
   }
 
   getSigner() {
@@ -145,14 +150,32 @@ export default class AggregatorService {
       sourceTimeout
     );
 
-    const filteredOptions = swapOptionsResponse.filter((option) => !('failed' in option)) as QuoteResponse[];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const validOptions = (swapOptionsResponse as (QuoteResponse | FailedQuote)[]).reduce(
+      (acc: QuoteResponse[], option) => {
+        if ('failed' in option) {
+          // eslint-disable-next-line no-void
+          void this.eventService.trackEvent('Aggregator - Fetching quote error', {
+            source: option.source.id,
+            sourceTimeout,
+            errorType: categorizeError(option.error),
+          });
+        } else {
+          // eslint-disable-next-line no-void
+          void this.eventService.trackEvent('Aggregator - Fetching quote successfull', { source: option.source.id });
+          acc.push(option);
+        }
+        return acc;
+      },
+      []
+    );
 
     const protocolToken = getProtocolToken(network);
 
     const sellToken = from.address === protocolToken.address ? protocolToken : toToken(from);
     const buyToken = to.address === protocolToken.address ? protocolToken : toToken(to);
 
-    let sortedOptions = filteredOptions.map<SwapOption>((quoteResponse) => ({
+    let sortedOptions = validOptions.map<SwapOption>((quoteResponse) => ({
       ...quoteResponseToSwapOption({
         ...quoteResponse,
         sellToken: {

--- a/src/services/web3Service.ts
+++ b/src/services/web3Service.ts
@@ -201,7 +201,8 @@ export default class Web3Service {
       this.apolloClient,
       this.providerService,
       this.safeService,
-      this.simulationService
+      this.simulationService,
+      this.eventService
     );
   }
 

--- a/src/types/aggregator.ts
+++ b/src/types/aggregator.ts
@@ -60,3 +60,5 @@ export interface SwapOptionWithFailure extends SwapOption {
 export interface SwapOptionWithTx extends SwapOption {
   tx: QuoteTransaction;
 }
+
+export type QuoteErrorType = 'Timeout' | 'ReferralCode' | 'BigIntConversion' | 'NetworkRequest' | 'Unknown';

--- a/src/types/aggregator.ts
+++ b/src/types/aggregator.ts
@@ -61,4 +61,10 @@ export interface SwapOptionWithTx extends SwapOption {
   tx: QuoteTransaction;
 }
 
-export type QuoteErrorType = 'Timeout' | 'ReferralCode' | 'BigIntConversion' | 'NetworkRequest' | 'Unknown';
+export enum QuoteErrors {
+  TIMEOUT = 'Timeout',
+  REFERRAL_CODE = 'ReferralCode',
+  BIGINT_CONVERSION = 'BigIntConversion',
+  NETWORK_REQUEST = 'NetworkRequest',
+  UNKNOWN = 'Unknown',
+}


### PR DESCRIPTION
From now on, we will be tracking failed quotes in MixPanel, including the error type and the `sourceTimeout` selected by the user. 

### Error Types
_Below are the different types of errors and an example of each as received by the application._

- Timeout: These errors occur when a request times out.

  > Request to https://api.mean.finance/v1/swap/networks/42220/quotes/0x timeouted at 3.5s

- ReferralCode: Errors related to invalid or unregistered referral codes.

  > Example: Odos: failed to calculate a quote between 0xeeeeee…ail\\":\\"Invalid or unregistered referral code\\"}"

- BigIntConversion: Errors arising from attempts to convert an undefined value to a BigInt.

  > Example: Cannot convert undefined to a BigInt

- NetworkRequest: General network request failures.

  > Example: Network request failed