### PR TITLE
chore: update sdk to improve buy orders

### DIFF
--- a/apps/root/package.json
+++ b/apps/root/package.json
@@ -94,7 +94,7 @@
     "@gnosis.pm/safe-apps-sdk": "^6.1.0",
     "@mean-finance/dca-v2-core": "^3.1.5",
     "@mean-finance/dca-v2-periphery": "^3.3.0",
-    "@mean-finance/sdk": "0.0.192",
+    "@mean-finance/sdk": "0.0.197",
     "@mean-finance/transformers": "^1.0.0",
     "@metamask/detect-provider": "^1.2.0",
     "@rainbow-me/rainbowkit": "^0.12.16",

--- a/apps/root/src/services/sdkService.ts
+++ b/apps/root/src/services/sdkService.ts
@@ -91,7 +91,6 @@ export default class SdkService {
             type: 'prioritized',
             sources: [
               { type: 'coingecko' },
-              { type: 'portals-fi' },
               // We place Mean Finance before DefiLlama because DefiLlama can quote 4626 tokens, but they are updated once
               // every hour. Mean's price source has the more up-to-date
               { type: 'mean-finance' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@0.0.192":
-  version "0.0.192"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.192.tgz#fa3c695ffa216af33656414662245654f9639dfc"
-  integrity sha512-kTSTzFA/rWQc14GniHIrcNWktKmFSihDDdW5Kei51d6VIep9uYXldcba0WsXoR+mArPYVKWWfScSPGmkTgUkHQ==
+"@mean-finance/sdk@0.0.197":
+  version "0.0.197"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.197.tgz#816a3fd0f55aab0f9a777017a6c00782bca7aef6"
+  integrity sha512-DjV51tCNmpi4m9B9zk261GgzCAm2q/L2c0ZjFI27Jlm4hntQsgl0JeqMru7ddhwVJYjeroq/ICi/dqZHQE9EGw==
   dependencies:
     alchemy-sdk "2.9.2"
     cross-fetch "3.1.5"


### PR DESCRIPTION
We are now update the SDK to include [this](https://github.com/Mean-Finance/sdk/commit/7c48e1e664abee0b381f2b6d712a59f45614002f) change. 

Now, when we estimate buy orders with sell orders, we take slippage into account. While this approach might not work 100% of the times, it should work far better than the current approach