### PR TITLE
chore: updates sdk

### DIFF
--- a/apps/root/package.json
+++ b/apps/root/package.json
@@ -94,7 +94,7 @@
     "@gnosis.pm/safe-apps-sdk": "^6.1.0",
     "@mean-finance/dca-v2-core": "^3.1.5",
     "@mean-finance/dca-v2-periphery": "^3.3.0",
-    "@mean-finance/sdk": "0.0.192",
+    "@mean-finance/sdk": "0.0.198",
     "@mean-finance/transformers": "^1.0.0",
     "@metamask/detect-provider": "^1.2.0",
     "@rainbow-me/rainbowkit": "^0.12.16",

--- a/apps/root/src/services/sdkService.ts
+++ b/apps/root/src/services/sdkService.ts
@@ -91,7 +91,6 @@ export default class SdkService {
             type: 'prioritized',
             sources: [
               { type: 'coingecko' },
-              { type: 'portals-fi' },
               // We place Mean Finance before DefiLlama because DefiLlama can quote 4626 tokens, but they are updated once
               // every hour. Mean's price source has the more up-to-date
               { type: 'mean-finance' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2585,7 +2585,7 @@
 "@mean-finance/sdk@0.0.198":
   version "0.0.198"
   resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.198.tgz#023cd11fc9e90e033392062f1c2f5f343c495aaf"
-  integrity sha512-h7nRvhYi7L1yUtvcgPCUPH03dyDXVecoLKBcd1tARJLyC3xsiUn5F2wa+Wtmmf6HTCU+MCoN+ZbblNaImvQl8Q=
+  integrity sha512-h7nRvhYi7L1yUtvcgPCUPH03dyDXVecoLKBcd1tARJLyC3xsiUn5F2wa+Wtmmf6HTCU+MCoN+ZbblNaImvQl8Q==
   dependencies:
     alchemy-sdk "2.9.2"
     cross-fetch "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@0.0.192":
-  version "0.0.192"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.192.tgz#fa3c695ffa216af33656414662245654f9639dfc"
-  integrity sha512-kTSTzFA/rWQc14GniHIrcNWktKmFSihDDdW5Kei51d6VIep9uYXldcba0WsXoR+mArPYVKWWfScSPGmkTgUkHQ==
+"@mean-finance/sdk@0.0.198":
+  version "0.0.198"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.198.tgz#023cd11fc9e90e033392062f1c2f5f343c495aaf"
+  integrity sha512-h7nRvhYi7L1yUtvcgPCUPH03dyDXVecoLKBcd1tARJLyC3xsiUn5F2wa+Wtmmf6HTCU+MCoN+ZbblNaImvQl8Q==
   dependencies:
     alchemy-sdk "2.9.2"
     cross-fetch "3.1.5"


### PR DESCRIPTION
By updating the SDK, we enable Braindex aggregator for Moonriver, and we also deprecate `portals-fi` which has been deprecated already by the SDK. Tested on my local env, and working sweet.