### PR TITLE
feat(home): No wallet connected case

### DIFF
--- a/apps/root/src/pages/aggregator/swap-container/components/quote-picker/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/components/quote-picker/index.tsx
@@ -21,7 +21,6 @@ const StyledContainer = styled(ForegroundPaper)`
   display: flex;
   flex-direction: column;
   gap: ${spacing(1)};
-  border-radius: ${spacing(4)};
   max-height: ${spacing(60)};
   overflow: auto;
   `}

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -13,7 +13,7 @@ import {
   ContainerBox,
   Typography,
   Button,
-  BackgroundPaper,
+  Paper,
 } from 'ui-library';
 import { FormattedMessage } from 'react-intl';
 import { formatCurrencyAmount, toSignificantFromBigDecimal } from '@common/utils/currency';
@@ -27,7 +27,7 @@ import { useDisconnect } from 'wagmi';
 import useUser from '@hooks/useUser';
 import styled from 'styled-components';
 
-const StyledNoWallet = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
+const StyledNoWallet = styled(Paper).attrs({ elevation: 0 })`
   ${({ theme: { spacing } }) => `
   display: flex;
   flex-direction: column;

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -13,7 +13,7 @@ import {
   ContainerBox,
   Typography,
   Button,
-  Paper,
+  ForegroundPaper,
 } from 'ui-library';
 import { FormattedMessage } from 'react-intl';
 import { formatCurrencyAmount, toSignificantFromBigDecimal } from '@common/utils/currency';
@@ -27,7 +27,7 @@ import { useDisconnect } from 'wagmi';
 import useUser from '@hooks/useUser';
 import styled from 'styled-components';
 
-const StyledNoWallet = styled(Paper).attrs({ elevation: 0 })`
+const StyledNoWallet = styled(ForegroundPaper).attrs({ variant: 'outlined' })`
   ${({ theme: { spacing } }) => `
   display: flex;
   flex-direction: column;

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -11,6 +11,9 @@ import {
   VirtualizedTable,
   buildVirtuosoTableComponents,
   ContainerBox,
+  Typography,
+  Button,
+  BackgroundPaper,
 } from 'ui-library';
 import { FormattedMessage } from 'react-intl';
 import { formatCurrencyAmount, toSignificantFromBigDecimal } from '@common/utils/currency';
@@ -19,6 +22,21 @@ import TokenIconWithNetwork from '@common/components/token-icon-with-network';
 import { useAllBalances } from '@state/balances/hooks';
 import { ALL_WALLETS, WalletOptionValues } from '@common/components/wallet-selector';
 import { formatUnits } from 'viem';
+import { useConnectModal } from '@rainbow-me/rainbowkit';
+import { useDisconnect } from 'wagmi';
+import useUser from '@hooks/useUser';
+import styled from 'styled-components';
+
+const StyledNoWallet = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
+  ${({ theme: { spacing } }) => `
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  gap: ${spacing(6)};
+  `}
+`;
 
 export type BalanceItem = {
   balance: bigint;
@@ -64,6 +82,43 @@ const PortfolioBodySkeleton: ItemContent<BalanceItem, Record<string, never>> = (
         </StyledBodyTypography>
       </TableCell>
     </>
+  );
+};
+
+const PortfolioNotConnected = () => {
+  const { openConnectModal } = useConnectModal();
+  const { disconnect } = useDisconnect({
+    onSettled() {
+      if (openConnectModal) {
+        openConnectModal();
+      }
+    },
+  });
+  const onConnectWallet = () => {
+    disconnect();
+
+    if (openConnectModal) {
+      openConnectModal();
+    }
+  };
+  return (
+    <StyledNoWallet>
+      <ContainerBox flexDirection="column" gap={2} alignItems="center">
+        <Typography variant="h5">💸️</Typography>
+        <Typography variant="h5" fontWeight="bold">
+          <FormattedMessage description="noWalletConnected" defaultMessage="No Wallet Connected" />
+        </Typography>
+        <Typography variant="body" textAlign="center">
+          <FormattedMessage
+            description="noWalletConnectedParagraph"
+            defaultMessage="Connect your wallet to view and manage your crypto portfolio"
+          />
+        </Typography>
+      </ContainerBox>
+      <Button variant="contained" size="large" onClick={onConnectWallet} fullWidth>
+        <FormattedMessage description="connectYourWallet" defaultMessage="Connect your wallet" />
+      </Button>
+    </StyledNoWallet>
   );
 };
 
@@ -133,6 +188,7 @@ const VirtuosoTableComponents = buildVirtuosoTableComponents<BalanceItem, Record
 
 const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
   const { isLoadingAllBalances, ...allBalances } = useAllBalances();
+  const user = useUser();
 
   const portfolioBalances = React.useMemo<BalanceItem[]>(() => {
     const tokenBalances = Object.values(allBalances).reduce<Record<string, BalanceItem>>(
@@ -170,6 +226,10 @@ const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
     const mappedBalances = map(Object.entries(tokenBalances), ([key, value]) => ({ ...value, key }));
     return orderBy(mappedBalances, [(item) => isUndefined(item.balanceUsd), 'balanceUsd'], ['asc', 'desc']);
   }, [selectedWalletOption, allBalances]);
+
+  if (!user) {
+    return <PortfolioNotConnected />;
+  }
 
   return (
     <VirtualizedTable

--- a/apps/root/src/pages/transfer/components/recipient-address/components/contacts-button/index.tsx
+++ b/apps/root/src/pages/transfer/components/recipient-address/components/contacts-button/index.tsx
@@ -17,6 +17,7 @@ const StyledContactsButton = styled(ForegroundPaper)`
   gap: ${spacing(0.5)};
   align-items: center;
   cursor: pointer;
+  border-radius: ${spacing(2)};
   &:hover {
     background-color: ${colors[palette.mode].background.tertiary};
   }

--- a/apps/root/src/state/balances/reducer.ts
+++ b/apps/root/src/state/balances/reducer.ts
@@ -19,7 +19,7 @@ export interface BalancesState {
   isLoadingAllBalances: boolean;
 }
 
-const initialState: BalancesState = { isLoadingAllBalances: true };
+const initialState: BalancesState = { isLoadingAllBalances: false };
 
 export default createReducer(initialState, (builder) => {
   builder

--- a/apps/root/src/state/index.ts
+++ b/apps/root/src/state/index.ts
@@ -156,7 +156,6 @@ const createStore = (web3Service: Web3Service) =>
             fetchable: true,
           },
         },
-        balances: { isLoadingAllBalances: true },
       },
     }),
   });

--- a/packages/ui-library/src/components/container-box/index.tsx
+++ b/packages/ui-library/src/components/container-box/index.tsx
@@ -18,10 +18,10 @@ const ContainerBox = styled.div<ContainerBoxProps>`
   flex-direction: ${({ flexDirection = 'row' }) => flexDirection};
   justify-content: ${({ justifyContent = 'flex-start' }) => justifyContent};
   align-items: ${({ alignItems = 'stretch' }) => alignItems};
+  flex: ${({ flex = '0 1 auto' }) => flex};
   flex-wrap: ${({ flexWrap = 'nowrap' }) => flexWrap};
   flex-grow: ${({ flexGrow = 0 }) => flexGrow};
   align-self: ${({ alignSelf = 'auto' }) => alignSelf};
-  flex: ${({ flex = '0 1 auto' }) => flex};
   width: ${({ fullWidth }) => fullWidth && '100%'};
   gap: ${({ gap, theme: { spacing } }) => gap && spacing(gap)};
 `;

--- a/packages/ui-library/src/components/foreground-paper/index.tsx
+++ b/packages/ui-library/src/components/foreground-paper/index.tsx
@@ -11,7 +11,7 @@ const StyledForegroundPaper = styled(Paper)`
     },
   }) => `
     background-color: ${colors[mode].background.secondary};
-    border-radius: ${spacing(2)};
+    border-radius: ${spacing(4)};
   `}
 `;
 const ForegroundPaper = ({ children, ...otherProps }: PaperProps) => (

--- a/packages/ui-library/src/components/token-picker/index.tsx
+++ b/packages/ui-library/src/components/token-picker/index.tsx
@@ -74,6 +74,7 @@ const StyledForegroundPaper = styled(ForegroundPaper)`
   }) => `
     gap: ${spacing(1)};
     padding: ${spacing(3)};
+    border-radius: ${spacing(2)};
     :hover {
       background-color: ${colors[mode].background.emphasis};
     }

--- a/packages/ui-library/src/components/virtualized-table/index.tsx
+++ b/packages/ui-library/src/components/virtualized-table/index.tsx
@@ -33,7 +33,7 @@ function buildVirtuosoTableComponents<D, C extends BaseContext>(): TableComponen
         context?: C;
       }
     >(function TableScroller(props, ref) {
-      return <TableContainer component={Paper} {...props} ref={ref} />;
+      return <TableContainer component={Paper} elevation={0} {...props} ref={ref} />;
     }),
     Table: (props) => <Table {...props} />,
     TableHead,

--- a/packages/ui-library/src/components/virtualized-table/index.tsx
+++ b/packages/ui-library/src/components/virtualized-table/index.tsx
@@ -33,7 +33,7 @@ function buildVirtuosoTableComponents<D, C extends BaseContext>(): TableComponen
         context?: C;
       }
     >(function TableScroller(props, ref) {
-      return <TableContainer component={Paper} elevation={0} {...props} ref={ref} />;
+      return <TableContainer component={Paper} variant="outlined" {...props} ref={ref} />;
     }),
     Table: (props) => <Table {...props} />,
     TableHead,

--- a/packages/ui-library/src/theme/components.ts
+++ b/packages/ui-library/src/theme/components.ts
@@ -43,6 +43,9 @@ const baseComponents: Components = {
       root: {
         backgroundImage: 'none',
       },
+      outlined: {
+        outlineStyle: 'solid',
+      },
     },
   },
   MuiDrawer: {


### PR DESCRIPTION
Fixed:
- No wallet connected on `<NetWorth />` and `<Portfolio />`
- Re-order styles on ContainerBox to enable Skeletons in `<Portfolio />` render as they should
- Elevation for our Virtualized Tables in order to match design 
- Set border-radius value for ForegroundPaper as default, based on main components (such as `Activity`)

### Previous behaviour
<img width="1214" alt="Screenshot 2024-02-29 at 17 25 46" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/b80053b3-8789-4149-8d72-d11a382c26d9">

### Current Demo
<img width="1195" alt="Screenshot 2024-02-29 at 17 52 34" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/01984595-226b-4f36-8679-a05158f5c1d2">
<img width="1200" alt="Screenshot 2024-02-29 at 17 51 49" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/6d33de3c-173b-41ec-b886-94f1adba51bf">
