### PR TITLE
fix(ContainerBox): Remove flexGrow default value

### DIFF
--- a/packages/ui-library/src/components/container-box/index.tsx
+++ b/packages/ui-library/src/components/container-box/index.tsx
@@ -20,7 +20,7 @@ const ContainerBox = styled.div<ContainerBoxProps>`
   align-items: ${({ alignItems = 'stretch' }) => alignItems};
   flex: ${({ flex = '0 1 auto' }) => flex};
   flex-wrap: ${({ flexWrap = 'nowrap' }) => flexWrap};
-  flex-grow: ${({ flexGrow = 0 }) => flexGrow};
+  ${({ flexGrow }) => flexGrow && `flex-grow: ${flexGrow};`}
   align-self: ${({ alignSelf = 'auto' }) => alignSelf};
   width: ${({ fullWidth }) => fullWidth && '100%'};
   gap: ${({ gap, theme: { spacing } }) => gap && spacing(gap)};


### PR DESCRIPTION
Having a default value for FlexGrow was always overriding flex shorthand value. This prop default value should be given by flex: default value (already specified as 0 from flex: 0 1 auto)