### PR TITLE
fix: update sdk to fix gas service

### DIFF
--- a/apps/root/package.json
+++ b/apps/root/package.json
@@ -94,7 +94,7 @@
     "@gnosis.pm/safe-apps-sdk": "^6.1.0",
     "@mean-finance/dca-v2-core": "^3.1.5",
     "@mean-finance/dca-v2-periphery": "^3.3.0",
-    "@mean-finance/sdk": "^0.0.221",
+    "@mean-finance/sdk": "0.0.221",
     "@mean-finance/transformers": "^1.0.0",
     "@metamask/detect-provider": "^1.2.0",
     "@rainbow-me/rainbowkit": "^0.12.16",

--- a/apps/root/package.json
+++ b/apps/root/package.json
@@ -94,7 +94,7 @@
     "@gnosis.pm/safe-apps-sdk": "^6.1.0",
     "@mean-finance/dca-v2-core": "^3.1.5",
     "@mean-finance/dca-v2-periphery": "^3.3.0",
-    "@mean-finance/sdk": "0.0.213",
+    "@mean-finance/sdk": "^0.0.221",
     "@mean-finance/transformers": "^1.0.0",
     "@metamask/detect-provider": "^1.2.0",
     "@rainbow-me/rainbowkit": "^0.12.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@0.0.213":
-  version "0.0.213"
-  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.213.tgz#e03ba92615d3ffbb465ad0c3200d633200bc7cc7"
-  integrity sha512-/qnaPm39N5hLFlM8PtvISAkxXrerL3hR/9qD4b+jQjBSTGW4V9r/SjuvZ/o1NuFEirO3rPV5opH/MncB89EbyQ==
+"@mean-finance/sdk@^0.0.221":
+  version "0.0.221"
+  resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.221.tgz#faeef494251145980cc8c6e069242cb06e40dd76"
+  integrity sha512-dh7NzDhecGXXxgAEu6cm8enOK9z/16hArCZjXyrZwK5GEfLepm05Kyo+HD3ESKiG09K1UuiSkOUEoU1ii2hyxg==
   dependencies:
     alchemy-sdk "2.9.2"
     cross-fetch "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,7 +2582,7 @@
     "@uniswap/v3-core" "1.0.1"
     moment "2.29.3"
 
-"@mean-finance/sdk@^0.0.221":
+"@mean-finance/sdk@0.0.221":
   version "0.0.221"
   resolved "https://registry.yarnpkg.com/@mean-finance/sdk/-/sdk-0.0.221.tgz#faeef494251145980cc8c6e069242cb06e40dd76"
   integrity sha512-dh7NzDhecGXXxgAEu6cm8enOK9z/16hArCZjXyrZwK5GEfLepm05Kyo+HD3ESKiG09K1UuiSkOUEoU1ii2hyxg==


### PR DESCRIPTION
We realized that some gas sources were returning invalid properties, so we added a way to filter them out here:
https://github.com/Mean-Finance/sdk/compare/1b99670d2f2debff721200c441da98d9b29f3dac...5abbb6132bb7d6c0ff851c7e615f3541d080586b