### PR TITLE
feat(dca): Transaction confirmation

### DIFF
--- a/apps/root/src/pages/aggregator/swap-container/components/swap/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/components/swap/index.tsx
@@ -1201,7 +1201,7 @@ const Swap = ({ isLoadingRoute, quotes, fetchOptions, swapOptionsError }: SwapPr
           actions={[
             {
               variant: 'contained',
-              color: 'secondary',
+              color: 'primary',
               onAction: handleNewTrade,
               label: intl.formatMessage({
                 description: 'transactionConfirmationNewTrade',

--- a/apps/root/src/pages/dca/create-position/components/swap/index.tsx
+++ b/apps/root/src/pages/dca/create-position/components/swap/index.tsx
@@ -976,14 +976,14 @@ const Swap = ({ currentNetwork, yieldOptions, isLoadingYieldOptions, handleChang
         }
         successTitle={
           <FormattedMessage
-            description="transactionConfirmationTransferSuccessful"
-            defaultMessage="Transfer successful"
+            description="transactionConfirmationPositionCreationSuccessful"
+            defaultMessage="Position creation successful"
           />
         }
         actions={[
           {
             variant: 'contained',
-            color: 'secondary',
+            color: 'primary',
             onAction: handleNewPosition,
             label: intl.formatMessage({
               description: 'transactionDCAConfirmationNewPosition',

--- a/apps/root/src/pages/transfer/components/transfer-form/index.tsx
+++ b/apps/root/src/pages/transfer/components/transfer-form/index.tsx
@@ -180,7 +180,7 @@ const TransferForm = () => {
           actions={[
             {
               variant: 'contained',
-              color: 'secondary',
+              color: 'primary',
               onAction: handleTransactionConfirmationClose,
               label: intl.formatMessage({ description: 'transactionConfirmationDone', defaultMessage: 'Done' }),
             },

--- a/packages/ui-library/src/components/transaction-confirmation/index.tsx
+++ b/packages/ui-library/src/components/transaction-confirmation/index.tsx
@@ -37,7 +37,8 @@ const StyledOverlay = styled.div`
     display: flex;
     flex-direction: column;
     gap: ${spacing(6)};
-    background-color: ${colors[mode].background.quarteryNoAlpha}
+    background-color: ${colors[mode].background.quarteryNoAlpha};
+    border-radius: inherit;
   `}
 `;
 


### PR DESCRIPTION
### Before
<img width="663" alt="Screenshot 2024-03-18 at 18 22 15" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/3b01a441-e258-4fda-a964-82da6f4c6d10">

### After
<img width="661" alt="Screenshot 2024-03-18 at 18 22 19" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/d0504697-cb7d-400b-a858-cd50607e8530">
