### PR TITLE
fix(portfolio): skeleton missing, column order and thickness

### DIFF
--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -134,7 +134,6 @@ const PortfolioNotConnected = () => {
     </StyledNoWallet>
   );
 };
-
 const PortfolioBodyItem: ItemContent<BalanceItem, Record<string, never>> = (
   index: number,
   { balance, token, isLoadingPrice, price, balanceUsd, relativeBalance }: BalanceItem
@@ -152,9 +151,7 @@ const PortfolioBodyItem: ItemContent<BalanceItem, Record<string, never>> = (
       </TableCell>
       <TableCell>
         <ContainerBox flexDirection="column">
-          <StyledBodyTypography>
-            {formatCurrencyAmount(balance, token, 3)} {token.symbol}
-          </StyledBodyTypography>
+          <StyledBodyTypography>{formatCurrencyAmount(balance, token, 3)}</StyledBodyTypography>
           <StyledBodySmallTypography>
             {isLoadingPrice && !price ? (
               <Skeleton variant="text" animation="wave" />

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -89,6 +89,11 @@ const PortfolioBodySkeleton: ItemContent<BalanceItem, Record<string, never>> = (
           <Skeleton variant="text" animation="wave" />
         </StyledBodyTypography>
       </TableCell>
+      <TableCell>
+        <StyledBodyTypography>
+          <Skeleton variant="text" animation="wave" sx={{ minWidth: '5ch' }} />
+        </StyledBodyTypography>
+      </TableCell>
     </>
   );
 };
@@ -137,6 +142,15 @@ const PortfolioBodyItem: ItemContent<BalanceItem, Record<string, never>> = (
   return (
     <>
       <TableCell>
+        <Grid container flexDirection={'row'} alignItems={'center'} gap={3}>
+          <TokenIconWithNetwork token={token} />
+          <ContainerBox flexDirection="column">
+            <StyledBodyTypography>{token.symbol}</StyledBodyTypography>
+            <StyledBodySmallTypography>{token.name}</StyledBodySmallTypography>
+          </ContainerBox>
+        </Grid>
+      </TableCell>
+      <TableCell>
         <ContainerBox flexDirection="column">
           <StyledBodyTypography>
             {formatCurrencyAmount(balance, token, 3)} {token.symbol}
@@ -151,15 +165,6 @@ const PortfolioBodyItem: ItemContent<BalanceItem, Record<string, never>> = (
         </ContainerBox>
       </TableCell>
       <TableCell>
-        <Grid container flexDirection={'row'} alignItems={'center'} gap={3}>
-          <TokenIconWithNetwork token={token} />
-          <ContainerBox flexDirection="column">
-            <StyledBodyTypography>{token.symbol}</StyledBodyTypography>
-            <StyledBodySmallTypography>{token.name}</StyledBodySmallTypography>
-          </ContainerBox>
-        </Grid>
-      </TableCell>
-      <TableCell>
         <StyledBodyTypography>
           {isLoadingPrice && !price ? (
             <Skeleton variant="text" animation="wave" />
@@ -170,11 +175,11 @@ const PortfolioBodyItem: ItemContent<BalanceItem, Record<string, never>> = (
       </TableCell>
       {relativeBalance !== 0 && (
         <TableCell>
-          {isLoadingPrice && !price ? (
+          {isNaN(relativeBalance) || isLoadingPrice || !price ? (
             <Skeleton variant="text" animation="wave" sx={{ minWidth: '5ch' }} />
           ) : (
             <ContainerBox alignItems="center" gap={3}>
-              <CircularProgressWithBrackground thickness={5} size={SPACING(6)} value={relativeBalance} />
+              <CircularProgressWithBrackground thickness={8} size={SPACING(6)} value={relativeBalance} />
               <StyledBodyTypography sx={{ color: ({ palette: { mode } }) => colors[mode].typography.typo3 }}>
                 {relativeBalance.toFixed(0)}%
               </StyledBodyTypography>
@@ -190,12 +195,12 @@ const PortfolioTableHeader = () => (
   <TableRow>
     <TableCell>
       <StyledBodySmallTypography>
-        <FormattedMessage description="portfolioBalanceCol" defaultMessage="Balance" />
+        <FormattedMessage description="portfolioAssetCol" defaultMessage="Asset" />
       </StyledBodySmallTypography>
     </TableCell>
     <TableCell>
       <StyledBodySmallTypography>
-        <FormattedMessage description="portfolioAssetCol" defaultMessage="Asset" />
+        <FormattedMessage description="portfolioBalanceCol" defaultMessage="Balance" />
       </StyledBodySmallTypography>
     </TableCell>
     <TableCell>

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -172,7 +172,7 @@ const PortfolioBodyItem: ItemContent<BalanceItem, Record<string, never>> = (
       </TableCell>
       {relativeBalance !== 0 && (
         <TableCell>
-          {isNaN(relativeBalance) || isLoadingPrice || !price ? (
+          {isLoadingPrice || !price ? (
             <Skeleton variant="text" animation="wave" sx={{ minWidth: '5ch' }} />
           ) : (
             <ContainerBox alignItems="center" gap={3}>
@@ -257,7 +257,7 @@ const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
     const mappedBalances = map(Object.entries(tokenBalances), ([key, value]) => ({
       ...value,
       key,
-      relativeBalance: ((value.balanceUsd || 0) / assetsTotalValue.wallet) * 100,
+      relativeBalance: ((value.balanceUsd || 0) / assetsTotalValue.wallet) * 100 || 0,
     }));
 
     return orderBy(mappedBalances, [(item) => isUndefined(item.balanceUsd), 'balanceUsd'], ['asc', 'desc']);

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -257,7 +257,8 @@ const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
     const mappedBalances = map(Object.entries(tokenBalances), ([key, value]) => ({
       ...value,
       key,
-      relativeBalance: ((value.balanceUsd || 0) / assetsTotalValue.wallet) * 100 || 0,
+      relativeBalance:
+        assetsTotalValue.wallet && value.balanceUsd ? (value.balanceUsd / assetsTotalValue.wallet) * 100 : 0,
     }));
 
     return orderBy(mappedBalances, [(item) => isUndefined(item.balanceUsd), 'balanceUsd'], ['asc', 'desc']);


### PR DESCRIPTION
While doing BLY-1980, I also detected that:

- There was a loading skeleton missing
- Thickness could look more similar to Figma's
- Also, if the screen loaded slow enough (set network to throttle) the percentage could show 'NaN' as value, added that to the logic of showing / not showing the value.

Prev
<img width="707" alt="image" src="https://github.com/Mean-Finance/dca-fe/assets/97693615/b5c1fa08-3337-4b1d-a441-20fe30f06dc5">


New
<img width="717" alt="image" src="https://github.com/Mean-Finance/dca-fe/assets/97693615/72d22c15-af8b-430a-be43-34e6232fea8c">
