### PR TITLE
fix(history): decimal parsing error when parsing api events

### DIFF
--- a/apps/root/src/common/utils/transaction-history/parsing.tsx
+++ b/apps/root/src/common/utils/transaction-history/parsing.tsx
@@ -82,7 +82,7 @@ const parseDcaCreatedApiEvent: ParseFunction<DCACreatedApiEvent, DCACreatedEvent
             : parseFloat(
                 formatUnits(
                   BigInt(event.data.rate) * parseUnits(event.data.fromToken.price.toString(), 18),
-                  dcaBaseEventData.toToken.decimals + 18
+                  dcaBaseEventData.fromToken.decimals + 18
                 )
               ).toFixed(2),
       },
@@ -95,7 +95,7 @@ const parseDcaCreatedApiEvent: ParseFunction<DCACreatedApiEvent, DCACreatedEvent
             : parseFloat(
                 formatUnits(
                   BigInt(funds) * parseUnits(event.data.fromToken.price.toString(), 18),
-                  dcaBaseEventData.toToken.decimals + 18
+                  dcaBaseEventData.fromToken.decimals + 18
                 )
               ).toFixed(2),
       },
@@ -133,7 +133,7 @@ const parseDcaModifiedApiEvent: ParseFunction<DCAModifiedApiEvent, DCAModifiedEv
             : parseFloat(
                 formatUnits(
                   BigInt(event.data.oldRate) * parseUnits(event.data.fromToken.price.toString(), 18),
-                  dcaBaseEventData.toToken.decimals + 18
+                  dcaBaseEventData.fromToken.decimals + 18
                 )
               ).toFixed(2),
       },
@@ -146,7 +146,7 @@ const parseDcaModifiedApiEvent: ParseFunction<DCAModifiedApiEvent, DCAModifiedEv
             : parseFloat(
                 formatUnits(
                   BigInt(difference) * parseUnits(event.data.fromToken.price.toString(), 18),
-                  dcaBaseEventData.toToken.decimals + 18
+                  dcaBaseEventData.fromToken.decimals + 18
                 )
               ).toFixed(2),
       },
@@ -159,7 +159,7 @@ const parseDcaModifiedApiEvent: ParseFunction<DCAModifiedApiEvent, DCAModifiedEv
             : parseFloat(
                 formatUnits(
                   BigInt(event.data.rate) * parseUnits(event.data.fromToken.price.toString(), 18),
-                  dcaBaseEventData.toToken.decimals + 18
+                  dcaBaseEventData.fromToken.decimals + 18
                 )
               ).toFixed(2),
       },


### PR DESCRIPTION
### Current behaviour
<img width="395" alt="Screenshot 2024-04-12 at 11 35 19 AM" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/f950eb11-20a1-466a-8f5e-2be5b54078cd">


### New behaviour
<img width="415" alt="Screenshot 2024-04-12 at 11 56 30 AM" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/4879c2d4-3a16-43ed-9d3a-9f204113610b">
