### PR TITLE
fix(txConfirmation): too much decimals for swap

### DIFF
--- a/apps/root/src/pages/aggregator/swap-container/components/swap/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/components/swap/index.tsx
@@ -1227,9 +1227,9 @@ const Swap = ({ isLoadingRoute, quotes, fetchOptions, swapOptionsError }: SwapPr
               defaultMessage: 'You are swapping {valueFrom} {from} for {valueTo} {to}.',
             }),
             {
-              valueFrom: selectedRoute?.sellAmount.amountInUnits || '',
+              valueFrom: selectedRoute && from ? formatCurrencyAmount(selectedRoute.sellAmount.amount, from, 4, 6) : '',
               from: selectedRoute?.sellToken.symbol || '',
-              valueTo: selectedRoute?.buyAmount.amountInUnits || '',
+              valueTo: selectedRoute && to ? formatCurrencyAmount(selectedRoute.buyAmount.amount, to, 4, 6) : '',
               to: selectedRoute?.buyToken.symbol || '',
             }
           )}

--- a/packages/ui-library/src/components/transaction-confirmation/index.tsx
+++ b/packages/ui-library/src/components/transaction-confirmation/index.tsx
@@ -32,16 +32,11 @@ import {
 
 // Max width same as button
 const StyledOverlay = styled.div`
-  ${({
-    theme: {
-      spacing,
-      palette: { mode },
-    },
-  }) => `
+  ${({ theme: { spacing } }) => `
     display: flex;
     flex-direction: column;
     gap: ${spacing(6)};
-    background-color: ${colors[mode].background.quartery};
+    margin: 0 auto;
     border-radius: inherit;
     max-width: ${spacing(87.5)};
   `}


### PR DESCRIPTION
Previous behaviour:
<img width="648" alt="Screenshot 2024-04-26 at 7 02 07 PM" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/e82c1353-923e-4fad-9ad9-faecc9d90bb1">

Current behaviour:
<img width="627" alt="Screenshot 2024-04-26 at 7 15 10 PM" src="https://github.com/Mean-Finance/dca-fe/assets/144699868/b6356559-b13a-428c-9130-d35a85bfc92d">

