### PR TITLE
fix: changes references and links from mean to balmy

### DIFF
--- a/apps/root/.template.env
+++ b/apps/root/.template.env
@@ -3,4 +3,4 @@ ETHPLORER_KEY=
 ETHERSCAN_API=
 MIXPANEL_TOKEN=
 WC_PROJECT_ID=
-MEAN_API_URL=https://api.mean.finance
+MEAN_API_URL=https://api.balmy.xyz

--- a/apps/root/README.md
+++ b/apps/root/README.md
@@ -26,4 +26,4 @@ Will run linter under [src](./src)
 
 ## 📖 Docs
 
-Check our docs at [docs.mean.finance](https://docs.mean.finance)
+Check our docs at [docs.balmy.xyz](https://docs.balmy.xyz)

--- a/apps/root/src/common/components/error-boundary/indext.tsx
+++ b/apps/root/src/common/components/error-boundary/indext.tsx
@@ -159,7 +159,7 @@ class ErrorBoundary extends Component<Props, State> {
           )}
           <Typography variant="bodySmallRegular">
             <FormattedMessage description="errorEncounteredDiscordPart1" defaultMessage="Come by to our" />
-            <StyledLink href="http://discord.mean.finance" target="_blank">
+            <StyledLink href="http://discord.balmy.xyz" target="_blank">
               discord
             </StyledLink>
             <FormattedMessage

--- a/apps/root/src/common/utils/errors.tsx
+++ b/apps/root/src/common/utils/errors.tsx
@@ -34,7 +34,7 @@ export const TRANSACTION_ERRORS = {
         description="unpredictableGasLimit"
         defaultMessage="You have encountered an error that we didn't know how to handle. Please copy the log and report this bug on"
       />
-      <StyledLink href="http://discord.mean.finance" target="_blank">
+      <StyledLink href="http://discord.balmy.xyz" target="_blank">
         <FormattedMessage description="ourDiscord" defaultMessage="our Discord" />
       </StyledLink>
     </>

--- a/apps/root/src/frame/components/footer/components/balmy-logo/index.tsx
+++ b/apps/root/src/frame/components/footer/components/balmy-logo/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import MeanLogoLight from '@assets/logo/light_logo.svg';
-import MeanLogoDark from '@assets/logo/dark_logo.svg';
+import BalmyLogoLight from '@assets/logo/light_logo.svg';
+import BalmyLogoDark from '@assets/logo/dark_logo.svg';
 
-interface MeanLogoProps {
+interface BalmyLogoProps {
   theme: 'light' | 'dark';
 }
-const MeanLogo = ({ theme }: MeanLogoProps) => (theme === 'light' ? <MeanLogoLight /> : <MeanLogoDark />);
+const BalmyLogo = ({ theme }: BalmyLogoProps) => (theme === 'light' ? <BalmyLogoLight /> : <BalmyLogoDark />);
 // <img
 //   alt="mean finance"
 //   style={{ width: '200px' }}
@@ -17,4 +17,4 @@ const MeanLogo = ({ theme }: MeanLogoProps) => (theme === 'light' ? <MeanLogoLig
 // />
 // )
 
-export default MeanLogo;
+export default BalmyLogo;

--- a/apps/root/src/frame/components/footer/index.tsx
+++ b/apps/root/src/frame/components/footer/index.tsx
@@ -7,14 +7,12 @@ import {
   TwitterIcon,
   PreviewIcon,
   DescriptionOutlinedIcon,
-  HelpOutlineOutlinedIcon,
   GithubIcon,
 } from 'ui-library';
 import styled from 'styled-components';
 import DiscordIcon from '@assets/svg/atom/discord';
 import { useThemeMode } from '@state/config/hooks';
 import useCurrentBreakpoint from '@hooks/useCurrentBreakpoint';
-import usePushToHistory from '@hooks/usePushToHistory';
 import LanguageLabel from './components/lang-label';
 import BalmyLogo from './components/balmy-logo';
 

--- a/apps/root/src/frame/components/footer/index.tsx
+++ b/apps/root/src/frame/components/footer/index.tsx
@@ -16,7 +16,7 @@ import { useThemeMode } from '@state/config/hooks';
 import useCurrentBreakpoint from '@hooks/useCurrentBreakpoint';
 import usePushToHistory from '@hooks/usePushToHistory';
 import LanguageLabel from './components/lang-label';
-import MeanLogo from './components/mean-logo';
+import BalmyLogo from './components/balmy-logo';
 
 const StyledFooterContainer = styled.div<{ isSmall: boolean }>`
   display: flex;
@@ -52,16 +52,10 @@ const Footer = () => {
   const mode = useThemeMode();
   const currentBreakPoint = useCurrentBreakpoint();
 
-  const pushToHistory = usePushToHistory();
-
-  const onFaqClick = () => {
-    pushToHistory('/faq');
-  };
-
   return (
     <StyledFooterContainer isSmall={currentBreakPoint === 'xs'}>
-      <Link href="https://mean.finance">
-        <MeanLogo theme={mode} />
+      <Link href="https://balmy.xyz">
+        <BalmyLogo theme={mode} />
       </Link>
       {currentBreakPoint !== 'xs' && (
         <>
@@ -69,10 +63,10 @@ const Footer = () => {
             <StyledLink underline="none" target="_blank" href="https://github.com/Mean-Finance">
               <GithubIcon />
             </StyledLink>
-            <StyledLink underline="none" target="_blank" href="https://twitter.com/mean_fi">
+            <StyledLink underline="none" target="_blank" href="https://twitter.com/balmy_xyz">
               <TwitterIcon />
             </StyledLink>
-            <StyledLink underline="none" target="_blank" href="http://discord.mean.finance">
+            <StyledLink underline="none" target="_blank" href="http://discord.balmy.xyz">
               <DiscordIcon size="24px" />
             </StyledLink>
           </StyledFooterMainContent>
@@ -96,16 +90,9 @@ const Footer = () => {
             </Typography>
 
             <Typography variant="bodySmallRegular">
-              <StyledLink underline="none" target="_blank" href="https://docs.mean.finance">
+              <StyledLink underline="none" target="_blank" href="https://docs.balmy.xyz">
                 <DescriptionOutlinedIcon fontSize="inherit" />
                 <FormattedMessage description="docs" defaultMessage="Docs" />
-              </StyledLink>
-            </Typography>
-
-            <Typography variant="bodySmallRegular">
-              <StyledLink underline="none" onClick={onFaqClick}>
-                <HelpOutlineOutlinedIcon fontSize="inherit" />
-                <FormattedMessage description="faq" defaultMessage="FAQ" />
               </StyledLink>
             </Typography>
 

--- a/apps/root/src/frame/components/navigation/index.tsx
+++ b/apps/root/src/frame/components/navigation/index.tsx
@@ -50,17 +50,17 @@ const helpOptions = [
   {
     label: defineMessage({ description: 'docs', defaultMessage: 'Docs' }),
     Icon: DocsIcon,
-    url: 'https://docs.mean.finance',
+    url: 'https://docs.balmy.xyz',
   },
   {
     label: defineMessage({ description: 'faq', defaultMessage: 'FAQ' }),
     Icon: HelpIcon,
-    url: 'https://mean.finance/faq',
+    url: 'https://balmy.xyz/faq',
   },
   {
     label: defineMessage({ description: 'contact&Support', defaultMessage: 'Contact & Support' }),
     Icon: SupportIcon,
-    url: 'http://discord.mean.finance',
+    url: 'http://discord.balmy.xyz',
   },
 ];
 const Navigation = ({ children }: React.PropsWithChildren) => {

--- a/apps/root/src/pages/dca/components/low-liquidity-modal/index.tsx
+++ b/apps/root/src/pages/dca/components/low-liquidity-modal/index.tsx
@@ -61,7 +61,7 @@ const LowLiquidityModal = ({ actionToTake, onConfirm, open, onCancel }: LowLiqui
           />
         </Typography>
         <Typography variant="bodyRegular" component="p">
-          <StyledLink href="https://docs.mean.finance/concepts/price-oracle" target="_blank">
+          <StyledLink href="https://docs.balmy.xyz/concepts/price-oracle" target="_blank">
             <FormattedMessage description="low liquidity link" defaultMessage="Read about price oracle" />
           </StyledLink>
         </Typography>

--- a/apps/root/src/pages/dca/positions/components/positions-list/position-card/components/position-warning/index.tsx
+++ b/apps/root/src/pages/dca/positions/components/positions-list/position-card/components/position-warning/index.tsx
@@ -63,7 +63,7 @@ const PositionWarning = ({ position }: PositionWarningProps) => {
           description="positionEulerHack1"
           defaultMessage="Euler has frozen the contracts after the hack, so modifying positions or withdrawing is not possible at the moment. You might be entitled to claim compensation, to do this visit the"
         />
-        <Link href="https://mean.finance/euler-claim" target="_blank">
+        <Link href="https://app.balmy.xyz/euler-claim" target="_blank">
           <FormattedMessage description="EulerClaim ClaimPage" defaultMessage="claim page" />
         </Link>
       </>

--- a/packages/ui-library/src/components/navigation/index.tsx
+++ b/packages/ui-library/src/components/navigation/index.tsx
@@ -273,10 +273,10 @@ const Navigation = ({
         <Link underline="none" target="_blank" href="https://github.com/Mean-Finance">
           <GithubIcon />
         </Link>
-        <Link underline="none" target="_blank" href="https://twitter.com/mean_fi">
+        <Link underline="none" target="_blank" href="https://twitter.com/balmy_xyz">
           <TwitterIcon />
         </Link>
-        <Link underline="none" target="_blank" href="http://discord.mean.finance">
+        <Link underline="none" target="_blank" href="http://discord.balmy.xyz">
           <DiscordIcon />
         </Link>
       </StyledDrawerFooterContainer>


### PR DESCRIPTION
Only references that are still waiting to be changed (since we do not know the exact urls):

- Link to audits
- Link to token list with new github repo name
- Link to github

Basically, everything that references the github. 

Additionally removed the FAQ since we don't have any place to link it too, at least yet 🫤
