### PR TITLE
feat(wallet-selector): enable header wallet selector + start tracking

### DIFF
--- a/apps/root/src/common/components/form-wallet-selector/index.tsx
+++ b/apps/root/src/common/components/form-wallet-selector/index.tsx
@@ -65,11 +65,20 @@ const WalletItem = ({
   );
 };
 
-interface FormWalletSelectorProps {
-  tokensToFilter?: Token[];
+// This prop is used only for tracking purposes. If the `NetWorth WalletSelector` is removed, this can be removed as well.
+export enum FormWalletSelectorApplication {
+  DCA = 'DCA',
+  SWAP = 'SWAP',
+  TRANSFER = 'TRANSFER',
+  EARN = 'EARN',
 }
 
-const FormWalletSelector = ({ tokensToFilter }: FormWalletSelectorProps) => {
+interface FormWalletSelectorProps {
+  tokensToFilter?: Token[];
+  application: FormWalletSelectorApplication;
+}
+
+const FormWalletSelector = ({ tokensToFilter, application }: FormWalletSelectorProps) => {
   const trackEvent = useTrackEvent();
   const accountService = useAccountService();
   const wallets = useWallets();
@@ -80,7 +89,7 @@ const FormWalletSelector = ({ tokensToFilter }: FormWalletSelectorProps) => {
   const selectedWallet = activeWallet?.address || find(wallets, { isAuth: true })?.address;
 
   const onClickWalletItem = (option: OptionWithKey) => {
-    trackEvent('Form Wallet selector - Changed active wallet');
+    trackEvent('Form Wallet selector - Changed active wallet', { application });
     void accountService.setActiveWallet(option.wallet.address);
   };
 

--- a/apps/root/src/common/components/wallet-selector/index.tsx
+++ b/apps/root/src/common/components/wallet-selector/index.tsx
@@ -100,10 +100,13 @@ const WalletSelector = ({ options, size = 'small' }: WalletSelectorProps) => {
     selectedWalletOption || activeWallet?.address || find(wallets, { isAuth: true })?.address || '';
 
   const onClickWalletItem = (newWallet: WalletOptionValues) => {
-    trackEvent('Wallet selector - Changed active wallet');
     if (setSelectionAsActive && newWallet !== ALL_WALLETS) {
+      trackEvent('Wallet selector - Changed active wallet');
       void accountService.setActiveWallet(newWallet);
+    } else {
+      trackEvent('Wallet selector - Changed view wallet');
     }
+
     if (onSelectWalletOption) {
       onSelectWalletOption(newWallet);
     }

--- a/apps/root/src/pages/aggregator/swap-container/components/step1/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/components/step1/index.tsx
@@ -22,7 +22,7 @@ import { usePortfolioPrices } from '@state/balances/hooks';
 import { compact } from 'lodash';
 import { parseNumberUsdPriceToBigInt, parseUsdPrice } from '@common/utils/currency';
 import { ContactListActiveModal } from '@common/components/contact-modal';
-import FormWalletSelector from '@common/components/form-wallet-selector';
+import FormWalletSelector, { FormWalletSelectorApplication } from '@common/components/form-wallet-selector';
 
 interface SwapFirstStepProps {
   from: Token | null;
@@ -189,7 +189,7 @@ const SwapFirstStep = ({
       <Grid item xs={12}>
         <ContainerBox flexDirection="column" gap={3}>
           <SwapNetworkSelector />
-          <FormWalletSelector />
+          <FormWalletSelector application={FormWalletSelectorApplication.SWAP} />
         </ContainerBox>
       </Grid>
       <Grid item xs={12}>

--- a/apps/root/src/pages/aggregator/swap-container/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/index.tsx
@@ -22,6 +22,7 @@ import { isAddress } from 'viem';
 import { useIsLoadingAllTokenLists } from '@state/token-lists/hooks';
 import usePrevious from '@hooks/usePrevious';
 import { FormattedMessage } from 'react-intl';
+import NetWorth from '@common/components/net-worth';
 
 const SwapContainer = () => {
   const { fromValue, from, to, toValue, isBuyOrder, selectedRoute, transferTo } = useAggregatorState();
@@ -120,6 +121,7 @@ const SwapContainer = () => {
   return (
     <ContainerBox flexDirection="column" gap={32} flex="0">
       <ContainerBox flexDirection="column" gap={6}>
+        <NetWorth walletSelector={{ options: { setSelectionAsActive: true } }} />
         <ContainerBox flexDirection="column" gap={2}>
           <Typography variant="h3Bold" color={({ palette }) => colors[palette.mode].typography.typo1}>
             <FormattedMessage defaultMessage="Swap" description="swap.title" />

--- a/apps/root/src/pages/dca/create-position/components/step1/index.tsx
+++ b/apps/root/src/pages/dca/create-position/components/step1/index.tsx
@@ -23,7 +23,7 @@ import { parseUnits } from 'viem';
 import { useTokenBalance } from '@state/balances/hooks';
 import useActiveWallet from '@hooks/useActiveWallet';
 import useAvailableSwapIntervals from '@hooks/useAvailableSwapIntervals';
-import FormWalletSelector from '@common/components/form-wallet-selector';
+import FormWalletSelector, { FormWalletSelectorApplication } from '@common/components/form-wallet-selector';
 
 const networkList = compact(
   orderBy(
@@ -129,7 +129,7 @@ const SwapFirstStep = ({
     <Grid container rowSpacing={6}>
       <Grid item xs={12}>
         <ContainerBox flexDirection="column" gap={3}>
-          <FormWalletSelector />
+          <FormWalletSelector application={FormWalletSelectorApplication.DCA} />
           <NetworkSelector disableSearch handleChangeCallback={onChangeNetwork} networkList={networkList} />
         </ContainerBox>
       </Grid>

--- a/apps/root/src/pages/dca/frame/index.tsx
+++ b/apps/root/src/pages/dca/frame/index.tsx
@@ -13,6 +13,7 @@ import usePositionService from '@hooks/usePositionService';
 import useUser from '@hooks/useUser';
 import useIsLoggingUser from '@hooks/useIsLoggingUser';
 import { FormattedMessage } from 'react-intl';
+import NetWorth from '@common/components/net-worth';
 
 interface DcaFrameProps {}
 
@@ -47,6 +48,7 @@ const DcaFrame = ({}: DcaFrameProps) => {
       ) : (
         <ContainerBox flexDirection="column" gap={32}>
           <ContainerBox flexDirection="column" gap={6}>
+            <NetWorth walletSelector={{ options: { setSelectionAsActive: true } }} />
             <ContainerBox flexDirection="column" gap={2}>
               <Typography variant="h3Bold" color={({ palette }) => colors[palette.mode].typography.typo1}>
                 <FormattedMessage defaultMessage="Recurring Investments" description="dca.title" />

--- a/apps/root/src/pages/strategy-guardian-detail/strategy-management/deposit/form/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/strategy-management/deposit/form/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ContainerBox } from 'ui-library';
 import EarnAssetInput from '../asset-input';
 import EarnDepositTransactionManager from '../tx-manager';
-import FormWalletSelector from '@common/components/form-wallet-selector';
+import FormWalletSelector, { FormWalletSelectorApplication } from '@common/components/form-wallet-selector';
 
 interface DepositFormProps {
   strategy?: DisplayStrategy;
@@ -22,7 +22,10 @@ const DepositForm = ({ strategy, setHeight }: DepositFormProps) => {
 
   return (
     <ContainerBox gap={3} flexDirection="column">
-      <FormWalletSelector tokensToFilter={strategy?.asset ? [strategy.asset] : undefined} />
+      <FormWalletSelector
+        tokensToFilter={strategy?.asset ? [strategy.asset] : undefined}
+        application={FormWalletSelectorApplication.EARN}
+      />
       <EarnAssetInput strategy={strategy} balance={balance} />
       <EarnDepositTransactionManager strategy={strategy} balance={balance} setHeight={setHeight} />
     </ContainerBox>

--- a/apps/root/src/pages/transfer/components/transfer-form/index.tsx
+++ b/apps/root/src/pages/transfer/components/transfer-form/index.tsx
@@ -40,7 +40,7 @@ import useWallets from '@hooks/useWallets';
 import useTrackEvent from '@hooks/useTrackEvent';
 import { formatUsdAmount } from '@common/utils/currency';
 import useValidateAddress from '@hooks/useValidateAddress';
-import FormWalletSelector from '@common/components/form-wallet-selector';
+import FormWalletSelector, { FormWalletSelectorApplication } from '@common/components/form-wallet-selector';
 
 const StyledTransferForm = styled(BackgroundPaper)`
   position: relative;
@@ -265,7 +265,7 @@ const TransferForm = () => {
           : !shouldShowConfirmation && (
               <>
                 <ContainerBox flexDirection="column" gap={3}>
-                  <FormWalletSelector />
+                  <FormWalletSelector application={FormWalletSelectorApplication.TRANSFER} />
                   <StyledRecipientContainer>
                     <RecipientAddress
                       validationResult={{ isValidAddress, errorMessage: addressErrorMessage }}

--- a/apps/root/src/pages/transfer/frame/index.tsx
+++ b/apps/root/src/pages/transfer/frame/index.tsx
@@ -6,6 +6,7 @@ import useTrackEvent from '@hooks/useTrackEvent';
 import { TRANSFER_ROUTE } from '@constants/routes';
 import TransferForm from '../components/transfer-form';
 import { FormattedMessage } from 'react-intl';
+import NetWorth from '@common/components/net-worth';
 
 interface TransferFrameProps {}
 
@@ -23,6 +24,7 @@ const TransferFrame = ({}: TransferFrameProps) => {
       <Grid item xs={12}>
         <ContainerBox flexDirection="column" gap={32} flex="0">
           <ContainerBox flexDirection="column" gap={6}>
+            <NetWorth walletSelector={{ options: { setSelectionAsActive: true } }} />
             <ContainerBox flexDirection="column" gap={2}>
               <Typography variant="h3Bold" color={({ palette }) => colors[palette.mode].typography.typo1}>
                 <FormattedMessage defaultMessage="Transfer" description="transfer.title" />


### PR DESCRIPTION
# New events
We will have 3 events in order to track wallet selection:

1. trackEvent('Wallet selector - Changed active wallet');
2. trackEvent('Wallet selector - Changed view wallet'); => Only applies to `Navigation` and `Portfolio`
3. trackEvent('Form Wallet selector - Changed active wallet', { application }); => Differentiates by application, so we can later exclude cases like `Earn`, where there is only one input

# Demo
<img width="1710" alt="Screenshot 2024-09-16 at 9 39 18 AM" src="https://github.com/user-attachments/assets/c565e78f-e000-40f8-86e5-b23e5f1258bf">
<img width="1710" alt="Screenshot 2024-09-16 at 9 39 25 AM" src="https://github.com/user-attachments/assets/cb0b110a-d0bd-45ff-b11f-80f0c266a24f">
<img width="1710" alt="Screenshot 2024-09-16 at 9 39 58 AM" src="https://github.com/user-attachments/assets/81f84ad4-e76e-43b7-b743-425689da3e82">
